### PR TITLE
Add configurable WPF Snellen chart renderer and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+**/bin/
+**/obj/
+/.vs/
+/TestResults/

--- a/LetterChart.sln
+++ b/LetterChart.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8BB6A363-FA18-4A84-9BB1-8547E10C3413}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetterChartApp", "src\LetterChartApp\LetterChartApp.csproj", "{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{FA51222E-E8F3-40CE-8349-96B4FEA91685}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetterChartApp.Tests", "tests\LetterChartApp.Tests\LetterChartApp.Tests.csproj", "{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetterChart.Core", "src\LetterChart.Core\LetterChart.Core.csproj", "{D6D88951-1206-4224-9E29-60883116A894}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6D88951-1206-4224-9E29-60883116A894}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6D88951-1206-4224-9E29-60883116A894}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6D88951-1206-4224-9E29-60883116A894}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6D88951-1206-4224-9E29-60883116A894}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7B9B100B-0549-41EA-BD8C-2CA4D5DA10F4} = {8BB6A363-FA18-4A84-9BB1-8547E10C3413}
+		{726C1113-F5B3-48A0-AE3E-19C4E5F9CA36} = {FA51222E-E8F3-40CE-8349-96B4FEA91685}
+		{D6D88951-1206-4224-9E29-60883116A894} = {8BB6A363-FA18-4A84-9BB1-8547E10C3413}
+	EndGlobalSection
+EndGlobal

--- a/src/LetterChart.Core/LetterChart.Core.csproj
+++ b/src/LetterChart.Core/LetterChart.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/LetterChart.Core/LetterChartBuilder.cs
+++ b/src/LetterChart.Core/LetterChartBuilder.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LetterChart.Core;
+
+public sealed class LetterChartBuilder
+{
+    public LetterChartDefinition BuildChart(LetterChartOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+
+        var lettersPerLine = options.GetLettersPerLine();
+        var generator = new LetterSequenceGenerator(options.AllowedLetters, options.PreferredLetters);
+        var lines = new List<LetterLineDefinition>(options.NumberOfLines);
+
+        for (var i = 0; i < options.NumberOfLines; i++)
+        {
+            var acuity = options.AcuityTargets[i];
+            var letterCount = lettersPerLine[i];
+            var letters = options.LetterSequences is { } sequences
+                ? sequences[i]
+                : generator.Generate(letterCount);
+
+            letters = new string(letters
+                .Where(char.IsLetter)
+                .Select(char.ToUpperInvariant)
+                .Take(letterCount)
+                .ToArray());
+
+            if (letters.Length != letterCount)
+            {
+                letters = letters.PadRight(letterCount, 'E');
+            }
+
+            var letterHeight = SnellenMath.GetLetterHeightPixels(
+                options.ViewingDistanceMeters,
+                options.PixelPitchMillimeters,
+                options.ScaleFactor,
+                acuity);
+
+            var lineSpacing = SnellenMath.GetLineSpacingPixels(letterHeight);
+            var letterSpacing = SnellenMath.GetLetterSpacingPixels(letterHeight);
+
+            var rotations = Enumerable.Repeat(0d, letters.Length).ToArray();
+
+            lines.Add(new LetterLineDefinition(
+                acuity,
+                letters,
+                letterHeight,
+                letterSpacing,
+                lineSpacing,
+                rotations));
+        }
+
+        return new LetterChartDefinition(lines, options.FontColor, options.BackgroundColor, options.ShowLeaderLines);
+    }
+
+    public LetterChartDefinition BuildTumblingChart(LetterChartOptions options, char symbol)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+
+        if (!char.IsLetter(symbol))
+        {
+            throw new ArgumentException("Symbol must be a letter.", nameof(symbol));
+        }
+
+        symbol = char.ToUpperInvariant(symbol);
+
+        var lettersPerLine = options.GetLettersPerLine();
+        var random = Random.Shared;
+        var lines = new List<LetterLineDefinition>(options.NumberOfLines);
+        var possibleAngles = new[] { 0d, 90d, 180d, 270d };
+
+        for (var i = 0; i < options.NumberOfLines; i++)
+        {
+            var acuity = options.AcuityTargets[i];
+            var letterCount = lettersPerLine[i];
+            var letters = new char[letterCount];
+            var rotations = new double[letterCount];
+
+            for (var j = 0; j < letterCount; j++)
+            {
+                letters[j] = symbol;
+                rotations[j] = possibleAngles[random.Next(possibleAngles.Length)];
+            }
+
+            var letterHeight = SnellenMath.GetLetterHeightPixels(
+                options.ViewingDistanceMeters,
+                options.PixelPitchMillimeters,
+                options.ScaleFactor,
+                acuity);
+
+            var lineSpacing = SnellenMath.GetLineSpacingPixels(letterHeight);
+            var letterSpacing = SnellenMath.GetLetterSpacingPixels(letterHeight);
+
+            lines.Add(new LetterLineDefinition(
+                acuity,
+                new string(letters),
+                letterHeight,
+                letterSpacing,
+                lineSpacing,
+                rotations));
+        }
+
+        return new LetterChartDefinition(lines, options.FontColor, options.BackgroundColor, options.ShowLeaderLines);
+    }
+}

--- a/src/LetterChart.Core/LetterChartOptions.cs
+++ b/src/LetterChart.Core/LetterChartOptions.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LetterChart.Core;
+
+public sealed class LetterChartOptions
+{
+    private static readonly SnellenFraction[] DefaultAcuityTargets =
+    {
+        new(20, 20),
+        new(20, 30),
+        new(20, 40)
+    };
+
+    public double ViewingDistanceMeters { get; init; } = 4.0;
+
+    public double PixelPitchMillimeters { get; init; } = 0.155;
+
+    public double ScaleFactor { get; init; } = 1.0;
+
+    public int NumberOfLines { get; init; } = 3;
+
+    public IReadOnlyList<SnellenFraction> AcuityTargets { get; init; } = DefaultAcuityTargets;
+
+    public IReadOnlyList<int>? LettersPerLine { get; init; }
+        = null; // null => infer based on acuity count.
+
+    public IReadOnlyList<string>? LetterSequences { get; init; }
+        = null; // null => generator chooses letters.
+
+    public ISet<char> PreferredLetters { get; init; } = new HashSet<char>("CDEFLNOPTZ");
+
+    public ISet<char> AllowedLetters { get; init; } = new HashSet<char>("ABCDEFGHJKLMNOPQRSTUVWXYZ");
+
+    public string FontColor { get; init; } = "#000000";
+
+    public string BackgroundColor { get; init; } = "#FFFFFF";
+
+    public bool ShowLeaderLines { get; init; } = true;
+
+    public void Validate()
+    {
+        if (ViewingDistanceMeters <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ViewingDistanceMeters));
+        }
+
+        if (PixelPitchMillimeters <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(PixelPitchMillimeters));
+        }
+
+        if (ScaleFactor <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ScaleFactor));
+        }
+
+        if (NumberOfLines <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(NumberOfLines));
+        }
+
+        if (AcuityTargets.Count < NumberOfLines)
+        {
+            throw new ArgumentException("Not enough acuity targets for the requested number of lines.", nameof(AcuityTargets));
+        }
+
+        if (LetterSequences is not null && LetterSequences.Count < NumberOfLines)
+        {
+            throw new ArgumentException("Not enough letter sequences for the requested number of lines.", nameof(LetterSequences));
+        }
+
+        if (LettersPerLine is not null && LettersPerLine.Count < NumberOfLines)
+        {
+            throw new ArgumentException("Not enough letter-count entries for the requested number of lines.", nameof(LettersPerLine));
+        }
+
+        if (AllowedLetters.Count == 0)
+        {
+            throw new ArgumentException("At least one allowed letter must be provided.", nameof(AllowedLetters));
+        }
+    }
+
+    public IReadOnlyList<int> GetLettersPerLine()
+    {
+        if (LettersPerLine is not null)
+        {
+            return LettersPerLine.Take(NumberOfLines).ToArray();
+        }
+
+        return Enumerable.Repeat(5, NumberOfLines).ToArray();
+    }
+}

--- a/src/LetterChart.Core/LetterLineDefinition.cs
+++ b/src/LetterChart.Core/LetterLineDefinition.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace LetterChart.Core;
+
+public sealed record LetterLineDefinition(
+    SnellenFraction Acuity,
+    string Letters,
+    double FontSize,
+    double LetterSpacing,
+    double LineSpacing,
+    IReadOnlyList<double> Rotations);
+
+public sealed record LetterChartDefinition(
+    IReadOnlyList<LetterLineDefinition> Lines,
+    string FontColor,
+    string BackgroundColor,
+    bool ShowLeaderLines);

--- a/src/LetterChart.Core/LetterSequenceGenerator.cs
+++ b/src/LetterChart.Core/LetterSequenceGenerator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LetterChart.Core;
+
+public sealed class LetterSequenceGenerator
+{
+    private readonly IReadOnlyList<char> _allowed;
+    private readonly IReadOnlyList<char> _preferred;
+    private readonly Random _random;
+
+    public LetterSequenceGenerator(ISet<char> allowed, ISet<char> preferred, int? seed = null)
+    {
+        if (allowed.Count == 0)
+        {
+            throw new ArgumentException("At least one allowed letter is required.", nameof(allowed));
+        }
+
+        _allowed = allowed.Select(char.ToUpperInvariant).Distinct().OrderBy(c => c).ToArray();
+        _preferred = preferred.Count == 0
+            ? Array.Empty<char>()
+            : preferred.Select(char.ToUpperInvariant).Distinct().Where(c => allowed.Contains(c)).OrderBy(c => c).ToArray();
+        _random = seed.HasValue ? new Random(seed.Value) : Random.Shared;
+    }
+
+    public string Generate(int count)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        Span<char> buffer = count <= 128 ? stackalloc char[count] : new char[count];
+        for (var i = 0; i < count; i++)
+        {
+            buffer[i] = NextLetter();
+        }
+
+        return new string(buffer);
+    }
+
+    private char NextLetter()
+    {
+        if (_preferred.Count == 0)
+        {
+            return _allowed[_random.Next(_allowed.Count)];
+        }
+
+        var usePreferred = _random.NextDouble() < 0.7; // Bias toward Sloan letters.
+        var source = usePreferred ? _preferred : _allowed;
+        return source[_random.Next(source.Count)];
+    }
+}

--- a/src/LetterChart.Core/SnellenFraction.cs
+++ b/src/LetterChart.Core/SnellenFraction.cs
@@ -1,0 +1,90 @@
+using System;
+
+namespace LetterChart.Core;
+
+/// <summary>
+/// Represents a Snellen visual acuity fraction (e.g. 20/20).
+/// </summary>
+public readonly struct SnellenFraction : IEquatable<SnellenFraction>
+{
+    public SnellenFraction(int numerator, int denominator)
+    {
+        if (numerator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(numerator), "Numerator must be positive.");
+        }
+
+        if (denominator <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(denominator), "Denominator must be positive.");
+        }
+
+        Numerator = numerator;
+        Denominator = denominator;
+    }
+
+    public int Numerator { get; }
+
+    public int Denominator { get; }
+
+    public double Ratio => (double)Numerator / Denominator;
+
+    public override string ToString() => $"{Numerator}/{Denominator}";
+
+    public static bool TryParse(string value, out SnellenFraction fraction)
+    {
+        fraction = default;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var parts = value.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], out var numerator))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], out var denominator))
+        {
+            return false;
+        }
+
+        if (numerator <= 0 || denominator <= 0)
+        {
+            return false;
+        }
+
+        fraction = new SnellenFraction(numerator, denominator);
+        return true;
+    }
+
+    public static SnellenFraction Parse(string value)
+    {
+        if (!TryParse(value, out var fraction))
+        {
+            throw new FormatException($"'{value}' is not a valid Snellen fraction.");
+        }
+
+        return fraction;
+    }
+
+    public bool Equals(SnellenFraction other)
+        => Numerator == other.Numerator && Denominator == other.Denominator;
+
+    public override bool Equals(object? obj)
+        => obj is SnellenFraction other && Equals(other);
+
+    public override int GetHashCode()
+        => HashCode.Combine(Numerator, Denominator);
+
+    public static bool operator ==(SnellenFraction left, SnellenFraction right) => left.Equals(right);
+
+    public static bool operator !=(SnellenFraction left, SnellenFraction right) => !left.Equals(right);
+}

--- a/src/LetterChart.Core/SnellenMath.cs
+++ b/src/LetterChart.Core/SnellenMath.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace LetterChart.Core;
+
+/// <summary>
+/// Provides utilities for computing Snellen letter dimensions and spacing.
+/// </summary>
+public static class SnellenMath
+{
+    private const double BaseArcMinutes = 5.0;
+
+    public static double GetLetterHeightMillimeters(double viewingDistanceMeters, SnellenFraction acuity)
+    {
+        if (viewingDistanceMeters <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(viewingDistanceMeters), "Viewing distance must be positive.");
+        }
+
+        var arcMinutes = BaseArcMinutes * acuity.Denominator / acuity.Numerator;
+        var radians = DegreesToRadians(arcMinutes / 60.0);
+        var halfAngle = radians / 2.0;
+        var distanceMillimeters = viewingDistanceMeters * 1000.0;
+        return 2.0 * distanceMillimeters * Math.Tan(halfAngle);
+    }
+
+    public static double GetLetterHeightPixels(double viewingDistanceMeters, double pixelPitchMillimeters, double scaleFactor, SnellenFraction acuity)
+    {
+        if (pixelPitchMillimeters <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pixelPitchMillimeters), "Pixel pitch must be positive.");
+        }
+
+        var heightMm = GetLetterHeightMillimeters(viewingDistanceMeters, acuity) * scaleFactor;
+        return heightMm / pixelPitchMillimeters;
+    }
+
+    public static double GetLetterSpacingPixels(double letterHeightPixels)
+        => letterHeightPixels; // ISO 8596 recommends spacing equal to letter width.
+
+    public static double GetLineSpacingPixels(double letterHeightPixels)
+        => letterHeightPixels; // Maintain one letter height between rows.
+
+    public static double DegreesToRadians(double degrees) => degrees * Math.PI / 180.0;
+}

--- a/src/LetterChartApp/App.xaml
+++ b/src/LetterChartApp/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="LetterChartApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+
+    </Application.Resources>
+</Application>

--- a/src/LetterChartApp/App.xaml.cs
+++ b/src/LetterChartApp/App.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace LetterChartApp;
+
+public partial class App : Application
+{
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        ChartLauncher.ShowDemoChart();
+    }
+}

--- a/src/LetterChartApp/ChartLauncher.cs
+++ b/src/LetterChartApp/ChartLauncher.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Windows;
+using LetterChart.Core;
+using LetterChartApp.ViewModels;
+
+namespace LetterChartApp;
+
+public static class ChartLauncher
+{
+    // Sloan optotype font closely matches clinical Snellen charts.
+    private const string DefaultFontFamily = "Sloan";
+
+    public static void ShowDemoChart()
+    {
+        var options = new LetterChartOptions
+        {
+            ViewingDistanceMeters = 4.0,
+            PixelPitchMillimeters = 0.155,
+            ScaleFactor = 1.0,
+            NumberOfLines = 3,
+            AcuityTargets = new List<SnellenFraction>
+            {
+                new(20, 20),
+                new(20, 30),
+                new(20, 40),
+            },
+            LettersPerLine = new List<int> { 5, 5, 5 },
+            ShowLeaderLines = true
+        };
+
+        var window = CreateChartWindow(options);
+        Application.Current.MainWindow = window;
+        window.Show();
+    }
+
+    public static ChartWindow CreateChartWindow(LetterChartOptions options, string fontFamily = DefaultFontFamily)
+    {
+        var builder = new LetterChartBuilder();
+        var definition = builder.BuildChart(options);
+        var viewModel = new ChartViewModel(definition, fontFamily);
+        return new ChartWindow(viewModel);
+    }
+
+    public static ChartWindow CreateTumblingEChart(LetterChartOptions options, string fontFamily = DefaultFontFamily)
+    {
+        var builder = new LetterChartBuilder();
+        var definition = builder.BuildTumblingChart(options, 'E');
+        var viewModel = new ChartViewModel(definition, fontFamily);
+        return new ChartWindow(viewModel);
+    }
+
+    public static ChartWindow CreateTumblingCChart(LetterChartOptions options, string fontFamily = DefaultFontFamily)
+    {
+        var builder = new LetterChartBuilder();
+        var definition = builder.BuildTumblingChart(options, 'C');
+        var viewModel = new ChartViewModel(definition, fontFamily);
+        return new ChartWindow(viewModel);
+    }
+
+    public static void ShowTumblingEChart(LetterChartOptions options, string fontFamily = DefaultFontFamily)
+    {
+        var window = CreateTumblingEChart(options, fontFamily);
+        Application.Current.MainWindow = window;
+        window.Show();
+    }
+
+    public static void ShowTumblingCChart(LetterChartOptions options, string fontFamily = DefaultFontFamily)
+    {
+        var window = CreateTumblingCChart(options, fontFamily);
+        Application.Current.MainWindow = window;
+        window.Show();
+    }
+}

--- a/src/LetterChartApp/ChartWindow.xaml
+++ b/src/LetterChartApp/ChartWindow.xaml
@@ -1,0 +1,125 @@
+<Window x:Class="LetterChartApp.ChartWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Letter Chart"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        WindowState="Maximized"
+        Background="{Binding BackgroundBrush}"
+        AllowsTransparency="False">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Window.Resources>
+    <Grid Margin="40">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <!-- Leader lines (left) -->
+        <ItemsControl Grid.Column="0"
+                      ItemsSource="{Binding Lines}"
+                      Visibility="{Binding ShowLeaderLines, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel VerticalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Margin="{Binding LeaderMargin}" Background="Transparent">
+                        <StackPanel Orientation="Horizontal"
+                                    VerticalAlignment="Center">
+                            <Rectangle Width="{Binding DataContext.LeaderLineLength, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       Height="1"
+                                       Fill="{Binding DataContext.LeaderBrush, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding LeaderText}"
+                                       Margin="8,0,0,0"
+                                       Foreground="{Binding DataContext.LeaderBrush, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       FontSize="{Binding DataContext.LeaderFontSize, RelativeSource={RelativeSource AncestorType=Window}}" />
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- Chart body -->
+        <Border Grid.Column="1"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                MaxWidth="{Binding MaxChartWidth}"
+                Background="Transparent">
+            <ItemsControl ItemsSource="{Binding Lines}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical"
+                                    Margin="{Binding LineMargin}"
+                                    HorizontalAlignment="Center">
+                            <ItemsControl ItemsSource="{Binding Letters}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="Transparent" Margin="{Binding Margin}">
+                                            <TextBlock Text="{Binding Character}"
+                                                       FontFamily="{Binding DataContext.FontFamily, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                       FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=ItemsControl, AncestorLevel=2}}"
+                                                       Foreground="{Binding Foreground}"
+                                                       RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock.RenderTransform>
+                                                    <RotateTransform Angle="{Binding Rotation}" />
+                                                </TextBlock.RenderTransform>
+                                            </TextBlock>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+
+        <!-- Leader lines (right) -->
+        <ItemsControl Grid.Column="2"
+                      ItemsSource="{Binding Lines}"
+                      Visibility="{Binding ShowLeaderLines, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel VerticalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Margin="{Binding LeaderMargin}" Background="Transparent">
+                        <StackPanel Orientation="Horizontal"
+                                    VerticalAlignment="Center"
+                                    FlowDirection="RightToLeft">
+                            <Rectangle Width="{Binding DataContext.LeaderLineLength, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       Height="1"
+                                       Fill="{Binding DataContext.LeaderBrush, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding LeaderText}"
+                                       Margin="8,0,0,0"
+                                       Foreground="{Binding DataContext.LeaderBrush, RelativeSource={RelativeSource AncestorType=Window}}"
+                                       FontSize="{Binding DataContext.LeaderFontSize, RelativeSource={RelativeSource AncestorType=Window}}" />
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</Window>

--- a/src/LetterChartApp/ChartWindow.xaml.cs
+++ b/src/LetterChartApp/ChartWindow.xaml.cs
@@ -1,0 +1,48 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using LetterChartApp.ViewModels;
+
+namespace LetterChartApp;
+
+public partial class ChartWindow : Window
+{
+    public ChartWindow(ChartViewModel viewModel)
+    {
+        InitializeComponent();
+        ViewModel = viewModel;
+        DataContext = viewModel;
+        Loaded += OnLoaded;
+        PreviewKeyDown += OnPreviewKeyDown;
+    }
+
+    public ChartViewModel ViewModel { get; }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        var width = SystemParameters.PrimaryScreenWidth * 0.66;
+        ViewModel.SetMaxChartWidth(width);
+    }
+
+    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+        }
+    }
+
+    public void SetLineColor(int lineIndex, Color color) => ViewModel.SetLineColor(lineIndex, color);
+
+    public void SetLetterColor(int lineIndex, int letterIndex, Color color)
+        => ViewModel.SetLetterColor(lineIndex, letterIndex, color);
+
+    public void HighlightLine(int lineIndex) => SetLineColor(lineIndex, Colors.Red);
+
+    public void HighlightLetter(int lineIndex, int letterIndex)
+        => SetLetterColor(lineIndex, letterIndex, Colors.Red);
+
+    public void ResetColors() => ViewModel.ResetColors();
+
+    public void SetLeaderLinesVisible(bool show) => ViewModel.SetLeaderLinesVisibility(show);
+}

--- a/src/LetterChartApp/LetterChartApp.csproj
+++ b/src/LetterChartApp/LetterChartApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <ItemGroup>
+    <ProjectReference Include="..\LetterChart.Core\LetterChart.Core.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/LetterChartApp/ObservableObject.cs
+++ b/src/LetterChartApp/ObservableObject.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace LetterChartApp;
+
+public abstract class ObservableObject : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (Equals(storage, value))
+        {
+            return;
+        }
+
+        storage = value;
+        OnPropertyChanged(propertyName);
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/LetterChartApp/ViewModels/ChartViewModel.cs
+++ b/src/LetterChartApp/ViewModels/ChartViewModel.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Windows.Media;
+using LetterChart.Core;
+using LetterChartApp;
+
+namespace LetterChartApp.ViewModels;
+
+public sealed class ChartViewModel : ObservableObject
+{
+    private double _maxChartWidth;
+    private bool _showLeaderLines;
+
+    public ChartViewModel(LetterChartDefinition definition, string fontFamilyName)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        FontFamily = new FontFamily(fontFamilyName);
+        BackgroundBrush = CreateBrush(definition.BackgroundColor);
+        LetterBrush = CreateBrush(definition.FontColor);
+        LeaderBrush = LetterBrush;
+        LeaderFontSize = 18;
+        LeaderLineLength = 192; // Approximately two inches at 96 DPI.
+        _showLeaderLines = definition.ShowLeaderLines;
+        Lines = CreateLines(definition, LetterBrush);
+    }
+
+    public ObservableCollection<LetterLineViewModel> Lines { get; }
+
+    public FontFamily FontFamily { get; }
+
+    public Brush BackgroundBrush { get; }
+
+    public Brush LetterBrush { get; }
+
+    public Brush LeaderBrush { get; }
+
+    public double LeaderFontSize { get; }
+
+    public double LeaderLineLength { get; }
+
+    public double MaxChartWidth
+    {
+        get => _maxChartWidth;
+        private set => SetProperty(ref _maxChartWidth, value);
+    }
+
+    public bool ShowLeaderLines
+    {
+        get => _showLeaderLines;
+        private set => SetProperty(ref _showLeaderLines, value);
+    }
+
+    public void SetMaxChartWidth(double width)
+    {
+        if (width <= 0)
+        {
+            return;
+        }
+
+        MaxChartWidth = width;
+    }
+
+    public void SetLeaderLinesVisibility(bool visible) => ShowLeaderLines = visible;
+
+    public void SetLineColor(int lineIndex, Color color)
+    {
+        if (lineIndex < 0 || lineIndex >= Lines.Count)
+        {
+            return;
+        }
+
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        Lines[lineIndex].SetLineForeground(brush);
+    }
+
+    public void SetLetterColor(int lineIndex, int letterIndex, Color color)
+    {
+        if (lineIndex < 0 || lineIndex >= Lines.Count)
+        {
+            return;
+        }
+
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        Lines[lineIndex].SetLetterForeground(letterIndex, brush);
+    }
+
+    public void ResetColors()
+    {
+        foreach (var line in Lines)
+        {
+            line.Reset();
+        }
+    }
+
+    private ObservableCollection<LetterLineViewModel> CreateLines(LetterChartDefinition definition, Brush brush)
+    {
+        var collection = new ObservableCollection<LetterLineViewModel>();
+        for (var i = 0; i < definition.Lines.Count; i++)
+        {
+            var isLast = i == definition.Lines.Count - 1;
+            collection.Add(new LetterLineViewModel(i + 1, definition.Lines[i], brush, isLast));
+        }
+
+        return collection;
+    }
+
+    private static Brush CreateBrush(string color)
+    {
+        var converter = new BrushConverter();
+        var brush = (Brush)converter.ConvertFromString(null, CultureInfo.InvariantCulture, color)!;
+        if (brush is SolidColorBrush solid)
+        {
+            solid.Freeze();
+        }
+
+        return brush;
+    }
+}

--- a/src/LetterChartApp/ViewModels/LetterCellViewModel.cs
+++ b/src/LetterChartApp/ViewModels/LetterCellViewModel.cs
@@ -1,0 +1,37 @@
+using System.Windows;
+using System.Windows.Media;
+using LetterChartApp;
+
+namespace LetterChartApp.ViewModels;
+
+public sealed class LetterCellViewModel : ObservableObject
+{
+    private Brush _foreground;
+
+    public LetterCellViewModel(char character, double rotation, Thickness margin, Brush foreground)
+    {
+        Character = character;
+        Rotation = rotation;
+        Margin = margin;
+        DefaultForeground = foreground;
+        _foreground = foreground;
+    }
+
+    public char Character { get; }
+
+    public double Rotation { get; }
+
+    public Thickness Margin { get; }
+
+    public Brush DefaultForeground { get; }
+
+    public Brush Foreground
+    {
+        get => _foreground;
+        private set => SetProperty(ref _foreground, value);
+    }
+
+    public void SetForeground(Brush brush) => Foreground = brush;
+
+    public void ResetForeground() => Foreground = DefaultForeground;
+}

--- a/src/LetterChartApp/ViewModels/LetterLineViewModel.cs
+++ b/src/LetterChartApp/ViewModels/LetterLineViewModel.cs
@@ -1,0 +1,96 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Media;
+using LetterChart.Core;
+using LetterChartApp;
+
+namespace LetterChartApp.ViewModels;
+
+public sealed class LetterLineViewModel : ObservableObject
+{
+    private readonly Brush _defaultBrush;
+    private Brush _lineForeground;
+
+    public LetterLineViewModel(int lineNumber, LetterLineDefinition definition, Brush brush, bool isLastLine)
+    {
+        LineNumber = lineNumber;
+        Acuity = definition.Acuity;
+        FontSize = definition.FontSize;
+        LineMargin = CreateLineMargin(lineNumber, definition.LineSpacing, isLastLine);
+        LeaderMargin = LineMargin;
+        _defaultBrush = brush;
+        _lineForeground = brush;
+        Letters = CreateLetters(definition, brush);
+        LeaderText = $"{lineNumber} {definition.Acuity}";
+    }
+
+    public int LineNumber { get; }
+
+    public SnellenFraction Acuity { get; }
+
+    public double FontSize { get; }
+
+    public Thickness LineMargin { get; }
+
+    public Thickness LeaderMargin { get; }
+
+    public string LeaderText { get; }
+
+    public ObservableCollection<LetterCellViewModel> Letters { get; }
+
+    public Brush LineForeground
+    {
+        get => _lineForeground;
+        private set => SetProperty(ref _lineForeground, value);
+    }
+
+    public void SetLineForeground(Brush brush)
+    {
+        LineForeground = brush;
+        foreach (var letter in Letters)
+        {
+            letter.SetForeground(brush);
+        }
+    }
+
+    public void SetLetterForeground(int index, Brush brush)
+    {
+        if (index < 0 || index >= Letters.Count)
+        {
+            return;
+        }
+
+        Letters[index].SetForeground(brush);
+    }
+
+    public void Reset()
+    {
+        LineForeground = _defaultBrush;
+        foreach (var letter in Letters)
+        {
+            letter.ResetForeground();
+        }
+    }
+
+    private static Thickness CreateLineMargin(int lineNumber, double lineSpacing, bool isLastLine)
+    {
+        var spacing = lineSpacing / 2.0;
+        var top = lineNumber == 1 ? 0 : spacing;
+        var bottom = isLastLine ? 0 : spacing;
+        return new Thickness(0, top, 0, bottom);
+    }
+
+    private ObservableCollection<LetterCellViewModel> CreateLetters(LetterLineDefinition definition, Brush brush)
+    {
+        var marginValue = definition.LetterSpacing / 2.0;
+        var margin = new Thickness(marginValue, 0, marginValue, 0);
+        var collection = new ObservableCollection<LetterCellViewModel>();
+
+        for (var i = 0; i < definition.Letters.Length; i++)
+        {
+            collection.Add(new LetterCellViewModel(definition.Letters[i], definition.Rotations[i], margin, brush));
+        }
+
+        return collection;
+    }
+}

--- a/tests/LetterChartApp.Tests/LetterChartApp.Tests.csproj
+++ b/tests/LetterChartApp.Tests/LetterChartApp.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LetterChart.Core\LetterChart.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/LetterChartApp.Tests/LetterChartBuilderTests.cs
+++ b/tests/LetterChartApp.Tests/LetterChartBuilderTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using LetterChart.Core;
+using Xunit;
+
+namespace LetterChartApp.Tests;
+
+public class LetterChartBuilderTests
+{
+    [Fact]
+    public void GeneratesLinesWithUppercaseLetters()
+    {
+        var options = new LetterChartOptions
+        {
+            ViewingDistanceMeters = 4,
+            PixelPitchMillimeters = 0.155,
+            NumberOfLines = 2,
+            AcuityTargets = new[] { new SnellenFraction(20, 20), new SnellenFraction(20, 30) },
+            LettersPerLine = new[] { 5, 5 },
+            LetterSequences = new[] { "abcde", "fghij" }
+        };
+
+        var builder = new LetterChartBuilder();
+        var chart = builder.BuildChart(options);
+
+        Assert.All(chart.Lines, line => Assert.True(line.Letters.All(char.IsUpper)));
+    }
+
+    [Fact]
+    public void TumblingChartProvidesRotations()
+    {
+        var options = new LetterChartOptions
+        {
+            ViewingDistanceMeters = 4,
+            PixelPitchMillimeters = 0.155,
+            NumberOfLines = 1,
+            AcuityTargets = new[] { new SnellenFraction(20, 20) },
+            LettersPerLine = new[] { 4 }
+        };
+
+        var builder = new LetterChartBuilder();
+        var chart = builder.BuildTumblingChart(options, 'E');
+
+        var line = Assert.Single(chart.Lines);
+        Assert.All(line.Letters, c => Assert.Equal('E', c));
+        Assert.All(line.Rotations, angle => Assert.Contains(angle, new[] { 0d, 90d, 180d, 270d }));
+    }
+}

--- a/tests/LetterChartApp.Tests/SnellenMathTests.cs
+++ b/tests/LetterChartApp.Tests/SnellenMathTests.cs
@@ -1,0 +1,27 @@
+using LetterChart.Core;
+using Xunit;
+
+namespace LetterChartApp.Tests;
+
+public class SnellenMathTests
+{
+    [Theory]
+    [InlineData(4.0, 20, 20, 5.82, 0.05)]
+    [InlineData(6.0, 20, 40, 17.45, 0.1)]
+    public void CalculatesExpectedLetterHeight(double distance, int numerator, int denominator, double expectedMm, double tolerance)
+    {
+        var acuity = new SnellenFraction(numerator, denominator);
+        var actual = SnellenMath.GetLetterHeightMillimeters(distance, acuity);
+        Assert.InRange(actual, expectedMm - tolerance, expectedMm + tolerance);
+    }
+
+    [Fact]
+    public void ConvertsToPixelsUsingPixelPitch()
+    {
+        var acuity = new SnellenFraction(20, 20);
+        var pixels = SnellenMath.GetLetterHeightPixels(4.0, 0.155, 1.0, acuity);
+        var expectedMm = SnellenMath.GetLetterHeightMillimeters(4.0, acuity);
+        var expectedPixels = expectedMm / 0.155;
+        Assert.InRange(pixels, expectedPixels - 0.01, expectedPixels + 0.01);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a core library that computes Snellen letter dimensions, spacing, and chart definitions from clinical parameters
- build a borderless WPF chart window with leader lines, Sloan optotype font support, highlighting helpers, and tumbling E/C variants
- add xUnit coverage for geometry calculations and chart generation logic

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e5a51817648333b14d1732a9ba5205